### PR TITLE
Added PlaybackType to FLoadingScreenDescription

### DIFF
--- a/Source/LoadingScreen/Private/LoadingScreenModule.cpp
+++ b/Source/LoadingScreen/Private/LoadingScreenModule.cpp
@@ -4,7 +4,6 @@
 #include "ILoadingScreenModule.h"
 
 #include "LoadingScreenSettings.h"
-#include "MoviePlayer.h"
 
 #include "SSimpleLoadingScreen.h"
 
@@ -84,7 +83,8 @@ void FLoadingScreenModule::BeginLoadingScreen(const FLoadingScreenDescription& S
 	LoadingScreen.bMoviesAreSkippable = ScreenDescription.bMoviesAreSkippable;
 	LoadingScreen.bWaitForManualStop = ScreenDescription.bWaitForManualStop;
 	LoadingScreen.MoviePaths = ScreenDescription.MoviePaths;
-
+	LoadingScreen.PlaybackType = ScreenDescription.PlaybackType;
+	
 	if ( ScreenDescription.bShowUIOverlay )
 	{
 		LoadingScreen.WidgetLoadingScreen = SNew(SSimpleLoadingScreen, ScreenDescription);

--- a/Source/LoadingScreen/Private/LoadingScreenSettings.h
+++ b/Source/LoadingScreen/Private/LoadingScreenSettings.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "SScaleBox.h"
+#include "MoviePlayer.h"
 
 #include "LoadingScreenSettings.generated.h"
 
@@ -28,6 +29,10 @@ struct LOADINGSCREEN_API FLoadingScreenDescription
 	/** If true, movie playback continues until Stop is called. */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category=Loading)
 	bool bWaitForManualStop;
+	
+	/** Should we just play back, loop, etc.  NOTE: if the playback type is MT_LoopLast, then bAutoCompleteWhenLoadingCompletes will be togged on when the last movie is hit*/
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category=Loading)
+	TEnumAsByte<EMoviePlaybackType> PlaybackType;
 
 	/**  Should we show the images/tips/loading text?  Generally you'll want to set this to false if you just want to show a movie. */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category=Display)


### PR DESCRIPTION
This is so the user has the option to make movies loop if a level takes longer to load than the duration of the movie.
